### PR TITLE
Fix first time download

### DIFF
--- a/lib/http-cache.js
+++ b/lib/http-cache.js
@@ -14,7 +14,7 @@ module.exports = file => {
     },
 
     async get(key) {
-      return data[key] || key
+      return data[key]
     },
 
     async clear() {

--- a/lib/http-cache.js
+++ b/lib/http-cache.js
@@ -14,7 +14,7 @@ module.exports = file => {
     },
 
     async get(key) {
-      return data[key]
+      return data[key] || key
     },
 
     async clear() {

--- a/lib/rollup.js
+++ b/lib/rollup.js
@@ -65,7 +65,7 @@ module.exports = ({ reload, cacheDir = CACHE_DIR } = {}) => {
       }
 
       // We have never requested this before
-      const res = await fetch(url)
+      const res = await fetch(id)
       file = getFilePathFromURL(res.url)
       await httpCache.set(id, res.url)
       const content = await res.buffer().then(buff => buff.toString('utf8'))


### PR DESCRIPTION
Hi,

With Rollup.js i wasn't able to « import "https://…" » i notice « Url is undefined » (line https://github.com/egoist/import-http/blob/master/lib/rollup.js#L57) when the targeted library isn't in the cache.

Since the URL is also the key its solve the problem.

OS: MacOS
NodeJS Version : 11.13.0
Bundler : RollupJS
Original log : 

```sh
$ rollup -c

src/main.js → dist/bundle.js...
Downloading undefined...
[!] Error: Could not load https://cdn.jsdelivr.net/npm/vue/dist/vue.esm.browser.js (imported by /Users/valentinbrosseau/dev/vue-yasb/src/main.js): Only absolute URLs are supported
Error: Could not load https://cdn.jsdelivr.net/npm/vue/dist/vue.esm.browser.js (imported by /Users/valentinbrosseau/dev/vue-yasb/src/main.js): Only absolute URLs are supported
    at /usr/local/lib/node_modules/rollup/dist/rollup.js:17855:19
    at process.runNextTicks [as _tickCallback] (internal/process/task_queues.js:52:5)
    at Function.Module.runMain (internal/modules/cjs/loader.js:871:11)
    at internal/main/run_main_module.js:21:11
```